### PR TITLE
chore: renovate schedule adjustments to create PRs just once a month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,17 +5,18 @@
   "enabledManagers": ["npm", "github-actions"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rangeStrategy": "update-lockfile",
-  "prHourlyLimit": 10,
   "labels": ["Dependacy"],
   "assigneesFromCodeOwners": true,
   "dependencyDashboardHeader": "",
-  "rebaseWhen": "auto",
   "osvVulnerabilityAlerts": true,
   "timezone": "America/Sao_Paulo",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
   },
+  "schedule": [
+    "before 10am on the first day of the month"
+  ],
   "packageRules": [
     {
       "groupName": "vitest monorepo",
@@ -43,9 +44,9 @@
       "automerge": true
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
-    }
+    }        
   ]
 }


### PR DESCRIPTION
Problema:
 o renovate bot estava gerando incontáveis PRs durante o dia com poucas atualizações, porém lockando o package.json e criando o risco de gerar incompatibilidade nas PRs que fazemos, aumentando o tempo de merge por conta das resoluções de conflito.
 
Solução:
 Criar um schedule para que o renovate faça PRs apenas uma vez por mês (no primeiro dia do mês) contemplando todas as atualizações. Assim uma pessoa fica pendente de validar riscos de incompatibilidade e gerar o merge quando/se fizer sentido.