### PR TITLE
refactor(renovate.json): refactored renovate bot

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -1,2 +1,13 @@
-- name: Renovate Bot GitHub Action
-  uses: renovatebot/github-action@v36.1.1
+name: Renovate
+on:
+  push:
+    branches:
+      - main
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Renovate Bot
+        uses: renovatebot/github-action@v36.1.1
+        with:
+          config-path: ./renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -2,49 +2,36 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":semanticCommits"],
   "enabled": true,
-  "enabledManagers": ["npm", "github-actions"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rangeStrategy": "update-lockfile",
-  "labels": ["Dependacy"],
-  "assigneesFromCodeOwners": true,
-  "dependencyDashboardHeader": "",
+  "labels": ["dependencies"],
   "osvVulnerabilityAlerts": true,
   "timezone": "America/Sao_Paulo",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": true,
+    "schedule": ["before 8am on monday"]
   },
   "schedule": ["before 10am on the first day of the month"],
   "packageRules": [
     {
-      "groupName": "vitest monorepo",
-      "groupSlug": "vitest",
-      "matchPackageNames": ["vitest"],
-      "matchPackagePrefixes": ["@vitest/"]
-    },
-    {
-      "matchPaths": ["package.json"],
-      "matchDepTypes": ["dependencies"],
-      "rangeStrategy": "pin"
-    },
-    {
-      "matchPaths": ["packages/**"],
-      "matchDepTypes": ["dependencies"],
-      "rangeStrategy": "replace"
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "rangeStrategy": "auto"
     },
     {
+      "groupName": "lint dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["lint", "prettier"],
-      "automerge": true
+      "automerge": true,
+      "rangeStrategy": "auto"
     },
     {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "groupName": "dev dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "auto"
     }
   ]
 }


### PR DESCRIPTION
**Problema:** 
 O renovate estava extenso, e considerando libs que não estávamos utilizando no projeto
 
 **Solução**
 Revisão do renovate e exploração de novas configurações.
 O que foi feito:

-  Ajuste no github actions. Tornar o renovate um job que segue seu próprio schedule no arquivo json
- Remoção de configurações usando NPM;
- Renomear as labels para seguir o padrão do renovate;
- Remover a opção para assignar as PRs aos code owners;
- Deixar o action call do header: essa opção deixa um link com o release notes mais a mão, facilitando a vida de quem vai atuar na validação da PR;
- lockFileMainteinance: merge automático toda segunda-feira;
- Remoção do vitest do regex;
- inserção de validação à partir de toda a estrutura do projeto;
- automerge de toda atualização em lint ou prettier;
- criação de PR para dev dependencies (_em avaliação_).
- PRs serão criados em lotes no primeiro dia de cada mês.