### PR TITLE
fix: renovate actions adjustments

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -1,8 +1,8 @@
 name: Renovate
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 4 * * 1"    
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -10,4 +10,4 @@ jobs:
       - name: Renovate Bot
         uses: renovatebot/github-action@v36.1.1
         with:
-          config-path: ./renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -18,20 +18,17 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "rangeStrategy": "auto"
+      "matchUpdateTypes": ["minor", "patch", "digest"]
     },
     {
       "groupName": "lint dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns": ["lint", "prettier"],
-      "automerge": true,
-      "rangeStrategy": "auto"
+      "automerge": true
     },
     {
       "groupName": "dev dependencies",
-      "matchDepTypes": ["devDependencies"],
-      "rangeStrategy": "auto"
+      "matchDepTypes": ["devDependencies"]
     }
   ]
 }


### PR DESCRIPTION
**Problema:**
O workflow do renovate actions não estava funcionando. O modelo do yaml está incorreto. 

**Solução**
Realizar os ajustes seguindo o padrão do github Actions.
De todo modo, é necessário criar um token para permitir que o actions possa criar as PRs. Esse token pode ser criado depois do PR inclusive, porém até ele ser gerado o workflow vai gerar erro na execução.